### PR TITLE
Fix glitch on Home page

### DIFF
--- a/covid/client/src/views/Home.vue
+++ b/covid/client/src/views/Home.vue
@@ -62,6 +62,10 @@ export default class Home extends Vue {
     return this.availableRooms.length !== 0;
   }
 
+  get availableRooms() {
+    return this.$store.getters.availableRooms;
+  }
+
   get fullName() {
     const sessionUser = this.$store.getters.sessionUser;
     return _.trim(_.join([sessionUser?.firstName, sessionUser?.lastName], " "));
@@ -72,15 +76,6 @@ export default class Home extends Vue {
     const fn = sessionUser?.firstName[0] || "";
     const ln = sessionUser?.lastName[0] || "";
     return _.trim(fn + ln);
-  }
-
-  get availableRooms() {
-    const allRooms = this.$store.getters.rooms;
-    if (this.currentRoom) {
-      return _.filter(allRooms, room => room.id !== this.currentRoom.id);
-    } else {
-      return allRooms;
-    }
   }
 
   mounted() {


### PR DESCRIPTION
In some cases, we were incorrectly showing a room when there wasn't. I fixed this by simplifying the logic for the `rooms` getter since we no longer need to have an array with all rooms containing all users. I also moved the logic of available rooms to the store and removed `activeRoom` because it's no longer being used.